### PR TITLE
make b1 completely real

### DIFF
--- a/bilby/gw/likelihood.py
+++ b/bilby/gw/likelihood.py
@@ -1657,8 +1657,8 @@ class RelativeBinningGravitationalWaveTransient(GravitationalWaveTransient):
 
                 b1[i] = noise_weighted_inner_product(
                     masked_h0_i,
-                    masked_h0_i * (masked_frequency_i - central_frequency_i),
-                    masked_psd_i,
+                    masked_h0_i,
+                    masked_psd_i / (masked_frequency_i - central_frequency_i),
                     self.waveform_generator.duration)
 
             summary_data[interferometer.name] = dict(a0=a0, a1=a1, b0=b0, b1=b1)


### PR DESCRIPTION
I noticed that ```b1``` wasn't real. It had some imaginary part that was of the order 1e-19 or so. The change I have made now shouldn't even make a difference, but it is somehow. Not sure how important this correction is.